### PR TITLE
Create necessary links for ubports-boot

### DIFF
--- a/functions/core.sh
+++ b/functions/core.sh
@@ -32,6 +32,10 @@ function flash() {
 			adb push $image /data/$image
 		fi
 	done
+
+	if [ "$1" == "ut" ]; then
+		adb shell ln /data/rootfs.img /data/system.img
+	fi
 }
 
 function clean() {

--- a/halium-install
+++ b/halium-install
@@ -77,7 +77,7 @@ echo "I: Shrinking images"
 shrink_images
 
 echo "I: Pushing rootfs and android image to /data via ADB"
-flash
+flash $ROOTFS_RELEASE
 
 echo "I: Cleaning up host"
 clean &


### PR DESCRIPTION
ubports-boot looks for `system.img` in `/data` instead of `rootfs.img`