### PR TITLE
Adapt to new halium-boot changes

### DIFF
--- a/functions/core.sh
+++ b/functions/core.sh
@@ -30,15 +30,8 @@ function unmount() {
 }
 
 function flash() {
-	for image in rootfs.img system.img; do
-		if [ -f $IMAGE_DIR/$image ]; then
-			adb push $IMAGE_DIR/$image /data/$image
-		fi
-	done
-
-	if [ "$1" == "ut" ]; then
-		adb shell ln /data/rootfs.img /data/system.img
-	fi
+	adb push $IMAGE_DIR/rootfs.img /data/
+	adb push $IMAGE_DIR/system.img /data/
 }
 
 function clean() {

--- a/functions/post-inst.sh
+++ b/functions/post-inst.sh
@@ -60,13 +60,6 @@ function post_install() {
 		sudo ln -s /android/system/vendor $ROOTFS_DIR/vendor
 		[ -e rootfs/etc/mtab ] && sudo rm $ROOTFS_DIR/etc/mtab
 		sudo ln -s /proc/mounts $ROOTFS_DIR/etc/mtab
-
-		# Remove or add globally after decison
-		# After the switch to halium-boot (initramfs-tools) this code is not needed for Ubuntu Touch anymore
-		echo -n "adding android system image to installation ... "
-		ANDROID_DIR="/var/lib/lxc/android/"
-		sudo mv system.img $ROOTFS_DIR/$ANDROID_DIR
-		echo "[done]"
 		;;
 	esac
 	sudo rm $ROOTFS_DIR/usr/bin/qemu-arm-static


### PR DESCRIPTION
This makes the Ubuntu Touch mode also use the normal halium image layout again, which is possible due to changes in halium-boot.