### PR TITLE
Add initial rsync transfer support

### DIFF
--- a/functions/core.sh
+++ b/functions/core.sh
@@ -37,9 +37,11 @@ function flash_adb() {
 }
 
 function flash_rsync() {
+	TARGET_ARCH=$(adb shell uname -m)
+
 	# Download prebuilt rsync
 	echo "[install] Installing rsync on the device ..."
-	! [ -f $IMAGE_DIR/rsync.bin ] && wget -O $IMAGE_DIR/rsync.bin --continue -q "https://github.com/JBBgameich/rsync-static/releases/download/continuous/rsync-arm"
+	! [ -f $IMAGE_DIR/rsync.bin ] && wget -O $IMAGE_DIR/rsync.bin --continue -q "https://github.com/JBBgameich/rsync-static/releases/download/continuous/rsync-$TARGET_ARCH"
 	! [ -f $IMAGE_DIR/rsyncd.conf ] && wget -O $IMAGE_DIR/rsyncd.conf --continue -q "https://raw.githubusercontent.com/JBBgameich/rsync-static/master/rsyncd.conf"
 
 	# Push rsync

--- a/functions/core.sh
+++ b/functions/core.sh
@@ -59,12 +59,6 @@ function flash_rsync() {
 	adb shell killall rsync
 }
 
-function flash_error() {
-	if ! $1; then
-		echo "Error: Couldn't copy the files to the device, is it connected?"
-	fi
-}
-
 function clean() {
 	# Delete created files from last install
 	sudo rm $ROOTFS_DIR $IMAGE_DIR -rf

--- a/functions/misc.sh
+++ b/functions/misc.sh
@@ -56,3 +56,7 @@ function usage() {
 	             defaults : none
 	EOF
 }
+
+function flash_error() {
+	echo "Error: Couldn't copy the files to the device, is it connected?"
+}

--- a/functions/misc.sh
+++ b/functions/misc.sh
@@ -60,3 +60,11 @@ function usage() {
 function flash_error() {
 	echo "Error: Couldn't copy the files to the device, is it connected?"
 }
+
+function debug_variables() {
+	echo "[Debug] rootfs: $ROOTFS_TAR"
+	echo "[Debug] android image: $AND_IMAGE"
+	echo "[Debug] release: $ROOTFS_RELEASE"
+	echo "[Debug] install method: $FLASH_METHOD"
+	echo
+}

--- a/functions/misc.sh
+++ b/functions/misc.sh
@@ -62,9 +62,9 @@ function flash_error() {
 }
 
 function debug_variables() {
-	echo "[Debug] rootfs: $ROOTFS_TAR"
-	echo "[Debug] android image: $AND_IMAGE"
-	echo "[Debug] release: $ROOTFS_RELEASE"
-	echo "[Debug] install method: $FLASH_METHOD"
+	echo "[debug] rootfs: $ROOTFS_TAR"
+	echo "[debug] android image: $AND_IMAGE"
+	echo "[debug] release: $ROOTFS_RELEASE"
+	echo "[debug] install method: $FLASH_METHOD"
 	echo
 }

--- a/halium-install
+++ b/halium-install
@@ -50,6 +50,9 @@ export AND_IMAGE=$2
 export ROOTFS_DIR=$(mktemp -d .halium-install-rootfs.XXXXX)
 export IMAGE_DIR=$(mktemp -d .halium-install-imgs.XXXXX)
 
+# Default to rsync installation
+export FLASH_RSYNC="true"
+
 # Start installer
 echo "Debug: Chosen rootfs is $ROOTFS_TAR"
 echo "Debug: Chosen android image is $AND_IMAGE"
@@ -76,9 +79,9 @@ shrink_images
 
 echo "I: Pushing rootfs and android image to /data"
 if [ $FLASH_ADB ]; then
-	flash_error flash_adb
-else
-	flash_error flash_rsync
+	flash_adb || flash_error
+elif [ $FLASH_RSYNC ]; then
+	flash_rsync || flash_error
 fi
 
 echo "I: Cleaning up host"

--- a/halium-install
+++ b/halium-install
@@ -50,15 +50,14 @@ export AND_IMAGE=$2
 export ROOTFS_DIR=$(mktemp -d .halium-install-rootfs.XXXXX)
 export IMAGE_DIR=$(mktemp -d .halium-install-imgs.XXXXX)
 
-# Default to rsync installation
-export FLASH_RSYNC="true"
+# Set defaults
+export ${FLASH_METHOD:="rsync"}
+export ${DEBUG:="true"}
+
+# Print out useful debugging information
+[ $DEBUG == "true" ] && debug_variables
 
 # Start installer
-echo "Debug: Chosen rootfs is $ROOTFS_TAR"
-echo "Debug: Chosen android image is $AND_IMAGE"
-echo "Debug: Chosen release is $ROOTFS_RELEASE"
-echo
-
 echo "I: Writing rootfs into mountable image"
 convert_rootfs $IMAGE_SIZE &>/dev/null &
 spinner $!
@@ -78,9 +77,9 @@ echo "I: Shrinking images"
 shrink_images
 
 echo "I: Pushing rootfs and android image to /data"
-if [ $FLASH_ADB ]; then
+if [ $FLASH_METHOD == "adb" ]; then
 	flash_adb || flash_error
-elif [ $FLASH_RSYNC ]; then
+elif [ $FLASH_METHOD == "rsync" ]; then
 	flash_rsync || flash_error
 fi
 

--- a/halium-install
+++ b/halium-install
@@ -74,9 +74,11 @@ spinner $!
 echo "I: Shrinking images"
 shrink_images
 
-echo "I: Pushing rootfs and android image to /data via ADB"
-if ! flash $ROOTFS_RELEASE; then
-	echo "Error: Couldn't copy the files to the device, is it connected?"
+echo "I: Pushing rootfs and android image to /data"
+if [ $FLASH_ADB ]; then
+	flash_error flash_adb
+else
+	flash_error flash_rsync
 fi
 
 echo "I: Cleaning up host"


### PR DESCRIPTION
Needs testers, but works on my device already
If you test this, please tell me whether it's faster or slower than ADB?
And sorry, this is currently only working on arm devices for the simple reason that I haven't found a good way to detect the architecture. For intel, you need to replace arm by x84 in the rsync download link manually.

You can still use ADB on this branch if you set `FLASH_METHOD=ADB` as environment variable.

TODO:
* [ ] Make architecture independent