### PR TITLE
Remove need to be in same directory as script

### DIFF
--- a/halium-install
+++ b/halium-install
@@ -10,6 +10,13 @@
 #
 # dependencies: qemu binfmt-support qemu-user-static e2fsprogs sudo simg2img
 
+LOCATION=`dirname "$0"`
+
+# Include functions
+source $LOCATION/functions/misc.sh
+source $LOCATION/functions/distributions.sh
+source $LOCATION/functions/core.sh
+
 # Opts parser, to be rewritten
 if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
 	usage
@@ -34,11 +41,6 @@ if [ "$#" -eq 3 ]; then
 else
 	ROOTFS_RELEASE="none"
 fi
-
-# Include functions
-. ./functions/misc.sh
-. ./functions/distributions.sh
-. ./functions/core.sh
 
 # Check for missing dependencies
 if ! init_checks; then

--- a/halium-install
+++ b/halium-install
@@ -14,8 +14,6 @@ LOCATION=`dirname "$0"`
 
 # Include functions
 source $LOCATION/functions/misc.sh
-source $LOCATION/functions/distributions.sh
-source $LOCATION/functions/core.sh
 
 # Opts parser, to be rewritten
 if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
@@ -51,6 +49,10 @@ export ROOTFS_TAR=$1
 export AND_IMAGE=$2
 export ROOTFS_DIR=$(mktemp -d .halium-install-rootfs.XXXXX)
 export IMAGE_DIR=$(mktemp -d .halium-install-imgs.XXXXX)
+
+# Logic that depends on the opts being parsed
+source $LOCATION/functions/distributions.sh
+source $LOCATION/functions/core.sh
 
 # Start installer
 echo "Debug: Chosen rootfs is $ROOTFS_TAR"


### PR DESCRIPTION
Use `dirname` to get the script file's location, then use that to source the remainder of the functions.

I also shuffled the order of the logic a bit, it was possible to make 'usage' get called before it was sourced before.

This is a bashism, but `#!/bin/bash` is the shebang so we should be fine.
