### PR TITLE
Sync write buffers after push finishes

### DIFF
--- a/functions/core.sh
+++ b/functions/core.sh
@@ -40,3 +40,8 @@ function clean() {
 	# Delete created files from last install
 	sudo rm $ROOTFS_DIR $IMAGE_DIR -rf
 }
+
+function clean_device() {
+	# Make sure the device is in a clean state
+	adb shell sync
+}

--- a/halium-install
+++ b/halium-install
@@ -82,3 +82,7 @@ fi
 echo "I: Cleaning up host"
 clean &
 spinner $!
+
+echo "I: Cleaning up device"
+clean_device &
+spinner $!


### PR DESCRIPTION
Some devices are *wonderful* and won't sync before they reboot, corrupting all of the files we just worked so hard to push. Let's manually sync at the end of the script to prevent that.