### PR TITLE
fix reference error and properly terminate on errors

### DIFF
--- a/functions/distributions.sh
+++ b/functions/distributions.sh
@@ -32,7 +32,7 @@ function setup_passwd() {
 }
 
 function chroot_run() {
-	sudo DEBIAN_FRONTEND=noninteractive LANG=C RUNLEVEL=1 chroot $ROOTFS_DIR /bin/bash -c "$@" || exit 1
+	sudo DEBIAN_FRONTEND=noninteractive LANG=C RUNLEVEL=1 chroot $ROOTFS_DIR /bin/bash -c "$@"
 }
 
 function post_install() {

--- a/halium-install
+++ b/halium-install
@@ -10,6 +10,8 @@
 #
 # dependencies: qemu binfmt-support qemu-user-static e2fsprogs sudo simg2img
 
+set -e # terminate on errors
+
 LOCATION="$(dirname "$(readlink -f "$0")")"
 
 # Defaults


### PR DESCRIPTION
* adding `set -e` makes sure any error anywhere in the script leads to a termination of the script instead of just carrying on with the next step 

* removing `exit 1` because the `id` tests are *supposed* to fail if user phablet doesn't exist (e.g. on reference rootfs)

fixes #28 